### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled command line

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -82,6 +82,11 @@ def handle_play_video():
         final_video_source = None
 
         if direct_video_url:
+            # Validate the direct video URL
+            if not (direct_video_url.startswith("http://") or direct_video_url.startswith("https://") or direct_video_url.startswith("file://")):
+                return jsonify({"status": "error", "message": "Invalid video URL scheme. Only http, https, and file schemes are allowed."}), 400
+            if not any(direct_video_url.endswith(ext) for ext in [".mp4", ".avi", ".mkv", ".mov"]):
+                return jsonify({"status": "error", "message": "Invalid video file format. Supported formats are: .mp4, .avi, .mkv, .mov."}), 400
             final_video_source = direct_video_url
             print(f"Using direct video URL from webhook: {direct_video_url}")
         elif requested_video_key:


### PR DESCRIPTION
Potential fix for [https://github.com/jrbenj/tikfinity-listener/security/code-scanning/3](https://github.com/jrbenj/tikfinity-listener/security/code-scanning/3)

To fix the issue, we need to validate the `direct_video_url` parameter before using it in the `command` list. The best approach is to ensure that the URL is safe and points to a valid video file. This can be achieved by:
1. Checking that the URL has a valid scheme (e.g., `http`, `https`, or `file`) and points to a supported video file format (e.g., `.mp4`, `.avi`).
2. Rejecting or sanitizing any input that does not meet these criteria.
3. Optionally, downloading the file to a temporary location and verifying its integrity before playback.

The changes will be made in the `handle_play_video` function to validate `direct_video_url` before passing it to `play_video_vlc`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
